### PR TITLE
Add Optional Delayed Adstock Transformation for More Flexible Carryover Effects

### DIFF
--- a/meridian/analysis/analyzer.py
+++ b/meridian/analysis/analyzer.py
@@ -406,6 +406,10 @@ class DistributionTensors(tf.experimental.ExtensionType):
   alpha_rf: Optional[tf.Tensor] = None
   alpha_om: Optional[tf.Tensor] = None
   alpha_orf: Optional[tf.Tensor] = None
+  theta_m: Optional[tf.Tensor] = None
+  theta_rf: Optional[tf.Tensor] = None
+  theta_om: Optional[tf.Tensor] = None
+  theta_orf: Optional[tf.Tensor] = None
   ec_m: Optional[tf.Tensor] = None
   ec_rf: Optional[tf.Tensor] = None
   ec_om: Optional[tf.Tensor] = None
@@ -1119,38 +1123,48 @@ class Analyzer:
     """
     params = []
     if self._meridian.media_tensors.media is not None:
-      params.extend([
-          constants.EC_M,
-          constants.SLOPE_M,
-          constants.ALPHA_M,
-          constants.BETA_GM,
-      ])
+      params.extend(
+          [
+              constants.EC_M,
+              constants.SLOPE_M,
+              constants.ALPHA_M,
+              constants.BETA_GM,
+          ]
+      )
     if self._meridian.rf_tensors.reach is not None:
-      params.extend([
-          constants.EC_RF,
-          constants.SLOPE_RF,
-          constants.ALPHA_RF,
-          constants.BETA_GRF,
-      ])
+      params.extend(
+          [
+              constants.EC_RF,
+              constants.SLOPE_RF,
+              constants.ALPHA_RF,
+              constants.BETA_GRF,
+          ]
+      )
     if include_non_paid_channels:
       if self._meridian.organic_media_tensors.organic_media is not None:
-        params.extend([
-            constants.EC_OM,
-            constants.SLOPE_OM,
-            constants.ALPHA_OM,
-            constants.BETA_GOM,
-        ])
+        params.extend(
+            [
+                constants.EC_OM,
+                constants.SLOPE_OM,
+                constants.ALPHA_OM,
+                constants.BETA_GOM,
+            ]
+        )
       if self._meridian.organic_rf_tensors.organic_reach is not None:
-        params.extend([
-            constants.EC_ORF,
-            constants.SLOPE_ORF,
-            constants.ALPHA_ORF,
-            constants.BETA_GORF,
-        ])
+        params.extend(
+            [
+                constants.EC_ORF,
+                constants.SLOPE_ORF,
+                constants.ALPHA_ORF,
+                constants.BETA_GORF,
+            ]
+        )
       if self._meridian.non_media_treatments is not None:
-        params.extend([
-            constants.GAMMA_GN,
-        ])
+        params.extend(
+            [
+                constants.GAMMA_GN,
+            ]
+        )
     return params
 
   def _get_transformed_media_and_beta(
@@ -1184,6 +1198,7 @@ class Analyzer:
           self._meridian.adstock_hill_media(
               media=data_tensors.media,
               alpha=dist_tensors.alpha_m,
+              theta=dist_tensors.theta_m,
               ec=dist_tensors.ec_m,
               slope=dist_tensors.slope_m,
               n_times_output=n_times_output,
@@ -1197,6 +1212,7 @@ class Analyzer:
               reach=data_tensors.reach,
               frequency=data_tensors.frequency,
               alpha=dist_tensors.alpha_rf,
+              theta=dist_tensors.theta_rf,
               ec=dist_tensors.ec_rf,
               slope=dist_tensors.slope_rf,
               n_times_output=n_times_output,
@@ -1208,6 +1224,7 @@ class Analyzer:
           self._meridian.adstock_hill_media(
               media=data_tensors.organic_media,
               alpha=dist_tensors.alpha_om,
+              theta=dist_tensors.theta_om,
               ec=dist_tensors.ec_om,
               slope=dist_tensors.slope_om,
               n_times_output=n_times_output,
@@ -1220,6 +1237,7 @@ class Analyzer:
               reach=data_tensors.organic_reach,
               frequency=data_tensors.organic_frequency,
               alpha=dist_tensors.alpha_orf,
+              theta=dist_tensors.theta_orf,
               ec=dist_tensors.ec_orf,
               slope=dist_tensors.slope_orf,
               n_times_output=n_times_output,
@@ -3029,16 +3047,20 @@ class Analyzer:
             "Effectiveness is not reported because it does not have a clear"
             " interpretation by time period."
         )
-        return xr.merge([
-            incremental_outcome,
-            pct_of_contribution,
-        ])
+        return xr.merge(
+            [
+                incremental_outcome,
+                pct_of_contribution,
+            ]
+        )
       else:
-        return xr.merge([
-            incremental_outcome,
-            pct_of_contribution,
-            effectiveness,
-        ])
+        return xr.merge(
+            [
+                incremental_outcome,
+                pct_of_contribution,
+                effectiveness,
+            ]
+        )
 
     # If non-paid channels are not included, return all metrics, paid and
     # non-paid.
@@ -3075,11 +3097,13 @@ class Analyzer:
           "ROI, mROI, Effectiveness, and CPIK are not reported because they "
           "do not have a clear interpretation by time period."
       )
-      return xr.merge([
-          spend_data,
-          incremental_outcome,
-          pct_of_contribution,
-      ])
+      return xr.merge(
+          [
+              spend_data,
+              incremental_outcome,
+              pct_of_contribution,
+          ]
+      )
     else:
       roi = self._compute_roi_aggregate(
           incremental_outcome_prior=incremental_outcome_prior,
@@ -3126,15 +3150,17 @@ class Analyzer:
           xr_coords=xr_coords_with_ci_and_distribution,
           confidence_level=confidence_level,
       )
-      return xr.merge([
-          spend_data,
-          incremental_outcome,
-          pct_of_contribution,
-          roi,
-          effectiveness,
-          mroi,
-          cpik,
-      ])
+      return xr.merge(
+          [
+              spend_data,
+              incremental_outcome,
+              pct_of_contribution,
+              roi,
+              effectiveness,
+              mroi,
+              cpik,
+          ]
+      )
 
   def get_aggregated_impressions(
       self,
@@ -3365,10 +3391,12 @@ class Analyzer:
         confidence_level=confidence_level,
     ).sel(channel=constants.BASELINE)
 
-    return xr.merge([
-        baseline_outcome,
-        baseline_pct_of_contribution,
-    ])
+    return xr.merge(
+        [
+            baseline_outcome,
+            baseline_pct_of_contribution,
+        ]
+    )
 
   def optimal_freq(
       self,
@@ -3549,20 +3577,24 @@ class Analyzer:
         selected_geos=selected_geos,
         selected_times=selected_times,
         use_kpi=use_kpi,
-    ).sel({
-        constants.CHANNEL: rf_channel_values,
-        constants.DISTRIBUTION: dist_type,
-    })
+    ).sel(
+        {
+            constants.CHANNEL: rf_channel_values,
+            constants.DISTRIBUTION: dist_type,
+        }
+    )
     optimized_metrics_by_frequency = self.summary_metrics(
         new_data=new_summary_metrics_data,
         marginal_roi_by_reach=False,
         selected_geos=selected_geos,
         selected_times=selected_times,
         use_kpi=use_kpi,
-    ).sel({
-        constants.CHANNEL: rf_channel_values,
-        constants.DISTRIBUTION: dist_type,
-    })
+    ).sel(
+        {
+            constants.CHANNEL: rf_channel_values,
+            constants.DISTRIBUTION: dist_type,
+        }
+    )
 
     data_vars = {
         constants.ROI: (
@@ -3824,10 +3856,12 @@ class Analyzer:
       perm = [1, 0] + list(range(2, n_dim))
       return tf.transpose(x, perm)
 
-    rhat = tfp.mcmc.potential_scale_reduction({
-        k: _transpose_first_two_dims(v)
-        for k, v in self._meridian.inference_data.posterior.data_vars.items()
-    })
+    rhat = tfp.mcmc.potential_scale_reduction(
+        {
+            k: _transpose_first_two_dims(v)
+            for k, v in self._meridian.inference_data.posterior.data_vars.items()
+        }
+    )
     return rhat
 
   def rhat_summary(self, bad_rhat_threshold: float = 1.2) -> pd.DataFrame:
@@ -3891,17 +3925,19 @@ class Analyzer:
         raise ValueError(f"Unexpected dimension for parameter {param}.")
 
       rhat_summary.append(
-          pd.Series({
-              constants.PARAM: param,
-              constants.N_PARAMS: np.prod(rhat[param].shape),
-              constants.AVG_RHAT: np.nanmean(rhat[param]),
-              constants.MAX_RHAT: np.nanmax(rhat[param]),
-              constants.PERCENT_BAD_RHAT: np.nanmean(
-                  rhat[param] > bad_rhat_threshold
-              ),
-              constants.ROW_IDX_BAD_RHAT: row_idx,
-              constants.COL_IDX_BAD_RHAT: col_idx,
-          })
+          pd.Series(
+              {
+                  constants.PARAM: param,
+                  constants.N_PARAMS: np.prod(rhat[param].shape),
+                  constants.AVG_RHAT: np.nanmean(rhat[param]),
+                  constants.MAX_RHAT: np.nanmax(rhat[param]),
+                  constants.PERCENT_BAD_RHAT: np.nanmean(
+                      rhat[param] > bad_rhat_threshold
+                  ),
+                  constants.ROW_IDX_BAD_RHAT: row_idx,
+                  constants.COL_IDX_BAD_RHAT: col_idx,
+              }
+          )
       )
     return pd.DataFrame(rhat_summary)
 
@@ -3984,11 +4020,13 @@ class Analyzer:
       reach = self._meridian.rf_tensors.reach
     if spend_multipliers is None:
       spend_multipliers = list(np.arange(0, 2.2, 0.2))
-    incremental_outcome = np.zeros((
-        len(spend_multipliers),
-        len(self._meridian.input_data.get_all_paid_channels()),
-        3,
-    ))
+    incremental_outcome = np.zeros(
+        (
+            len(spend_multipliers),
+            len(self._meridian.input_data.get_all_paid_channels()),
+            3,
+        )
+    )
     for i, multiplier in enumerate(spend_multipliers):
       if multiplier == 0:
         incremental_outcome[i, :, :] = tf.zeros(

--- a/meridian/constants.py
+++ b/meridian/constants.py
@@ -179,6 +179,10 @@ NATIONAL = 'national'
 NATIONAL_MODEL_DEFAULT_GEO_NAME = 'national_geo'
 NATIONAL_MODEL_DEFAULT_POPULATION_VALUE = 1.0
 
+# Adstock function types
+ADSTOCK_GEOMETRIC = 'geometric'
+ADSTOCK_DELAYED = 'delayed'
+ADSTOCK_FUNCTIONS = (ADSTOCK_GEOMETRIC, ADSTOCK_DELAYED)
 
 # Media random effects distributions.
 MEDIA_EFFECTS_NORMAL = 'normal'
@@ -204,11 +208,13 @@ BASELINE_GEO = 'baseline_geo'
 PAID_MEDIA_PRIOR_TYPE_ROI = 'roi'
 PAID_MEDIA_PRIOR_TYPE_MROI = 'mroi'
 PAID_MEDIA_PRIOR_TYPE_COEFFICIENT = 'coefficient'
-PAID_MEDIA_PRIOR_TYPES = frozenset({
-    PAID_MEDIA_PRIOR_TYPE_ROI,
-    PAID_MEDIA_PRIOR_TYPE_MROI,
-    PAID_MEDIA_PRIOR_TYPE_COEFFICIENT,
-})
+PAID_MEDIA_PRIOR_TYPES = frozenset(
+    {
+        PAID_MEDIA_PRIOR_TYPE_ROI,
+        PAID_MEDIA_PRIOR_TYPE_MROI,
+        PAID_MEDIA_PRIOR_TYPE_COEFFICIENT,
+    }
+)
 PAID_MEDIA_ROI_PRIOR_TYPES = frozenset(
     {PAID_MEDIA_PRIOR_TYPE_ROI, PAID_MEDIA_PRIOR_TYPE_MROI}
 )
@@ -245,6 +251,8 @@ XI_C = 'xi_c'
 XI_N = 'xi_n'
 ALPHA_M = 'alpha_m'
 ALPHA_RF = 'alpha_rf'
+THETA_M = 'theta_m'
+THETA_RF = 'theta_rf'
 EC_M = 'ec_m'
 EC_RF = 'ec_rf'
 SLOPE_M = 'slope_m'
@@ -261,6 +269,8 @@ ETA_OM = 'eta_om'
 ETA_ORF = 'eta_orf'
 ALPHA_OM = 'alpha_om'
 ALPHA_ORF = 'alpha_orf'
+THETA_OM = 'theta_om'
+THETA_ORF = 'theta_orf'
 EC_OM = 'ec_om'
 EC_ORF = 'ec_orf'
 SLOPE_OM = 'slope_om'
@@ -311,6 +321,7 @@ ORGANIC_MEDIA_PARAMETERS = (
     BETA_OM,
     ETA_OM,
     ALPHA_OM,
+    THETA_OM,
     EC_OM,
     SLOPE_OM,
 )
@@ -318,6 +329,7 @@ ORGANIC_RF_PARAMETERS = (
     BETA_ORF,
     ETA_ORF,
     ALPHA_ORF,
+    THETA_ORF,
     EC_ORF,
     SLOPE_ORF,
 )
@@ -327,8 +339,26 @@ NON_MEDIA_PARAMETERS = (
 )
 
 KNOTS_PARAMETERS = (KNOT_VALUES,)
-MEDIA_PARAMETERS = (ETA_M, BETA_M, ALPHA_M, EC_M, SLOPE_M, ROI_M, MROI_M)
-RF_PARAMETERS = (ETA_RF, BETA_RF, ALPHA_RF, EC_RF, SLOPE_RF, ROI_RF, MROI_RF)
+MEDIA_PARAMETERS = (
+    ETA_M,
+    BETA_M,
+    ALPHA_M,
+    THETA_M,
+    EC_M,
+    SLOPE_M,
+    ROI_M,
+    MROI_M,
+)
+RF_PARAMETERS = (
+    ETA_RF,
+    BETA_RF,
+    ALPHA_RF,
+    THETA_RF,
+    EC_RF,
+    SLOPE_RF,
+    ROI_RF,
+    MROI_RF,
+)
 CONTROL_PARAMETERS = (GAMMA_C, XI_C)
 SIGMA_PARAMETERS = (SIGMA,)
 GEO_PARAMETERS = (
@@ -366,11 +396,13 @@ UNSAVED_PARAMETERS = (
     GAMMA_GN_DEV,
     TAU_G_EXCL_BASELINE,  # Used to derive TAU_G.
 )
-IGNORED_PRIORS = immutabledict.immutabledict({
-    PAID_MEDIA_PRIOR_TYPE_ROI: (BETA_M, BETA_RF, MROI_M, MROI_RF),
-    PAID_MEDIA_PRIOR_TYPE_MROI: (BETA_M, BETA_RF, ROI_M, ROI_RF),
-    PAID_MEDIA_PRIOR_TYPE_COEFFICIENT: (ROI_M, ROI_RF, MROI_M, MROI_RF),
-})
+IGNORED_PRIORS = immutabledict.immutabledict(
+    {
+        PAID_MEDIA_PRIOR_TYPE_ROI: (BETA_M, BETA_RF, MROI_M, MROI_RF),
+        PAID_MEDIA_PRIOR_TYPE_MROI: (BETA_M, BETA_RF, ROI_M, ROI_RF),
+        PAID_MEDIA_PRIOR_TYPE_COEFFICIENT: (ROI_M, ROI_RF, MROI_M, MROI_RF),
+    }
+)
 
 # Inference data dimensions.
 INFERENCE_DIMS = immutabledict.immutabledict(
@@ -405,20 +437,24 @@ N_STEPS = 'n_steps'
 SAMPLE_SHAPE = 'sample_shape'
 SEED = 'seed'
 
-SAMPLE_STATS_METRICS = immutabledict.immutabledict({
-    STEP_SIZE: STEP_SIZE,
-    TARGET_LOG_PROBABILITY_TF: TARGET_LOG_PROBABILITY_ARVIZ,
-    DIVERGING: DIVERGING,
-    N_STEPS: N_STEPS,
-})
+SAMPLE_STATS_METRICS = immutabledict.immutabledict(
+    {
+        STEP_SIZE: STEP_SIZE,
+        TARGET_LOG_PROBABILITY_TF: TARGET_LOG_PROBABILITY_ARVIZ,
+        DIVERGING: DIVERGING,
+        N_STEPS: N_STEPS,
+    }
+)
 
 
 # Adstock hill functions.
-ADSTOCK_HILL_FUNCTIONS = frozenset({
-    'adstock_memory_optimized',
-    'adstock_speed_optimized',
-    'hill',
-})
+ADSTOCK_HILL_FUNCTIONS = frozenset(
+    {
+        'adstock_memory_optimized',
+        'adstock_speed_optimized',
+        'hill',
+    }
+)
 
 
 # Distribution constants.
@@ -600,6 +636,8 @@ DEFAULT_CONFIDENCE_LEVEL = 0.9
 # Default number of max draws per chain in Analyzer.expected_outcome()
 DEFAULT_BATCH_SIZE = 100
 
+# Default number of max lag in ModelSpec
+DEFAULT_MAX_LAG = 8
 
 # Optimization constants.
 CHAINS_DIMENSION = 0

--- a/meridian/model/adstock_hill_test.py
+++ b/meridian/model/adstock_hill_test.py
@@ -24,8 +24,8 @@ import tensorflow_probability as tfp
 tfd = tfp.distributions
 
 
-class TestAdstock(parameterized.TestCase):
-  """Tests for adstock()."""
+class TestGeometricAdstock(parameterized.TestCase):
+  """Tests for geometric adstock"""
 
   # Data dimensions for default parameter values.
   _N_CHAINS = 2
@@ -45,19 +45,19 @@ class TestAdstock(parameterized.TestCase):
   def test_raises(self):
     """Test that exceptions are raised as expected."""
     with self.assertRaisesRegex(ValueError, "`n_times_output` cannot exceed"):
-      adstock_hill.AdstockTransformer(
+      adstock_hill.GeometricAdstockTransformer(
           alpha=self._ALPHA,
           max_lag=self._MAX_LAG,
           n_times_output=self._N_MEDIA_TIMES + 1,
       ).forward(self._MEDIA)
     with self.assertRaisesRegex(ValueError, "`media` batch dims do not"):
-      adstock_hill.AdstockTransformer(
+      adstock_hill.GeometricAdstockTransformer(
           alpha=self._ALPHA[1:, ...],
           max_lag=self._MAX_LAG,
           n_times_output=self._N_MEDIA_TIMES,
       ).forward(self._MEDIA)
     with self.assertRaisesRegex(ValueError, "`media` contains a different"):
-      adstock_hill.AdstockTransformer(
+      adstock_hill.GeometricAdstockTransformer(
           alpha=self._ALPHA,
           max_lag=self._MAX_LAG,
           n_times_output=self._N_MEDIA_TIMES,
@@ -65,11 +65,11 @@ class TestAdstock(parameterized.TestCase):
     with self.assertRaisesRegex(
         ValueError, "`n_times_output` must be positive"
     ):
-      adstock_hill.AdstockTransformer(
+      adstock_hill.GeometricAdstockTransformer(
           alpha=self._ALPHA, max_lag=self._MAX_LAG, n_times_output=0
       ).forward(self._MEDIA)
     with self.assertRaisesRegex(ValueError, "`max_lag` must be non-negative"):
-      adstock_hill.AdstockTransformer(
+      adstock_hill.GeometricAdstockTransformer(
           alpha=self._ALPHA, max_lag=-1, n_times_output=self._N_MEDIA_TIMES
       ).forward(self._MEDIA)
 
@@ -94,7 +94,7 @@ class TestAdstock(parameterized.TestCase):
       ),
       dict(
           testcase_name="max_lag > n_media_times",
-          media=_MEDIA[..., :(_MAX_LAG - 1)],
+          media=_MEDIA[..., : (_MAX_LAG - 1)],
           alpha=_ALPHA,
           n_time_output=_N_MEDIA_TIMES,
       ),
@@ -107,13 +107,13 @@ class TestAdstock(parameterized.TestCase):
   )
   def test_basic_output(self, media, alpha, n_time_output):
     """Basic test for valid output."""
-    media_transformed = adstock_hill.AdstockTransformer(
+    media_transformed = adstock_hill.GeometricAdstockTransformer(
         alpha, self._MAX_LAG, n_time_output
-        ).forward(media)
+    ).forward(media)
     output_shape = tf.TensorShape(
         alpha.shape[:-1] + media.shape[-3] + [n_time_output] + alpha.shape[-1]
     )
-    msg = f"{adstock_hill.AdstockTransformer.__name__}() failed."
+    msg = f"{adstock_hill.GeometricAdstockTransformer.__name__}() failed."
     tf.debugging.assert_equal(
         media_transformed.shape, output_shape, message=msg
     )
@@ -121,7 +121,7 @@ class TestAdstock(parameterized.TestCase):
     tf.debugging.assert_non_negative(media_transformed, message=msg)
 
   def test_max_lag_zero(self):
-    media_transformed = adstock_hill.AdstockTransformer(
+    media_transformed = adstock_hill.GeometricAdstockTransformer(
         alpha=self._ALPHA,
         max_lag=0,
         n_times_output=self._N_MEDIA_TIMES,
@@ -129,7 +129,7 @@ class TestAdstock(parameterized.TestCase):
     tf.debugging.assert_near(media_transformed, self._MEDIA)
 
   def test_alpha_zero(self):
-    media_transformed = adstock_hill.AdstockTransformer(
+    media_transformed = adstock_hill.GeometricAdstockTransformer(
         alpha=tf.zeros_like(self._ALPHA),
         max_lag=self._MAX_LAG,
         n_times_output=self._N_MEDIA_TIMES,
@@ -137,7 +137,7 @@ class TestAdstock(parameterized.TestCase):
     tf.debugging.assert_near(media_transformed, self._MEDIA)
 
   def test_media_zero(self):
-    media_transformed = adstock_hill.AdstockTransformer(
+    media_transformed = adstock_hill.GeometricAdstockTransformer(
         alpha=self._ALPHA,
         max_lag=self._MAX_LAG,
         n_times_output=self._N_MEDIA_TIMES,
@@ -147,7 +147,7 @@ class TestAdstock(parameterized.TestCase):
     tf.debugging.assert_near(media_transformed, tf.zeros_like(self._MEDIA))
 
   def test_alpha_close_to_one(self):
-    media_transformed = adstock_hill.AdstockTransformer(
+    media_transformed = adstock_hill.GeometricAdstockTransformer(
         alpha=0.99999 * tf.ones_like(self._ALPHA),
         max_lag=self._N_MEDIA_TIMES - 1,
         n_times_output=self._N_MEDIA_TIMES,
@@ -161,7 +161,7 @@ class TestAdstock(parameterized.TestCase):
 
   def test_media_all_ones(self):
     # Calculate adstock on a media vector of all ones and no lag history.
-    media_transformed = adstock_hill.AdstockTransformer(
+    media_transformed = adstock_hill.GeometricAdstockTransformer(
         alpha=self._ALPHA,
         max_lag=self._MAX_LAG,
         n_times_output=self._N_MEDIA_TIMES,
@@ -169,8 +169,7 @@ class TestAdstock(parameterized.TestCase):
     # n_nonzero_terms is a tensor with length containing the number of nonzero
     # terms in the adstock for each output time period.
     n_nonzero_terms = np.minimum(
-        np.arange(1, self._N_MEDIA_TIMES + 1),
-        self._MAX_LAG + 1
+        np.arange(1, self._N_MEDIA_TIMES + 1), self._MAX_LAG + 1
     )
     # For each output time period and alpha value, the adstock is given by
     # adstock = series1 / series2, where:
@@ -190,10 +189,284 @@ class TestAdstock(parameterized.TestCase):
     result = term1 / term2[:, :, None, :]
     # Broadcast `result` across geos.
     result = tf.tile(
-        result[:, :, None, :, :],
-        multiples=[1, 1, self._N_GEOS, 1, 1]
+        result[:, :, None, :, :], multiples=[1, 1, self._N_GEOS, 1, 1]
     )
     tf.debugging.assert_near(media_transformed, result)
+
+
+class TestDelayedAdstock(parameterized.TestCase):
+  """Tests for the Delayed Adstock transformation of media."""
+
+  # Data dimensions for default parameter values.
+  _N_CHAINS = 2
+  _N_DRAWS = 5
+  _N_GEOS = 4
+  _N_MEDIA_TIMES = 10
+  _N_MEDIA_CHANNELS = 3
+  _MAX_LAG = 5
+
+  # Generate random data based on dimensions specified above.
+  tf.random.set_seed(1)
+  _MEDIA = tfd.HalfNormal(1).sample(
+      [
+          _N_CHAINS,
+          _N_DRAWS,
+          _N_GEOS,
+          _N_MEDIA_TIMES,
+          _N_MEDIA_CHANNELS,
+      ]
+  )
+  _ALPHA = tfd.Uniform(0, 1).sample([_N_CHAINS, _N_DRAWS, _N_MEDIA_CHANNELS])
+  _THETA = tfd.Uniform(0, float(_MAX_LAG)).sample(
+      [_N_CHAINS, _N_DRAWS, _N_MEDIA_CHANNELS]
+  )
+
+  @staticmethod
+  def _manual_delayed_adstock(media, alpha, theta, max_lag, n_times_output):
+    """Manually compute delayed adstock output following the implementation."""
+    n_media_times = media.shape[-2]
+    window_size = min(max_lag + 1, n_media_times)
+    required_n_media_times = n_times_output + window_size - 1
+
+    if n_media_times < required_n_media_times:
+      pad = np.zeros(
+          media.shape[:-2]
+          + (required_n_media_times - n_media_times,)
+          + media.shape[-1:],
+          dtype=media.dtype,
+      )
+      media_used = np.concatenate([pad, media], axis=-2)
+    elif n_media_times > required_n_media_times:
+      media_used = media[..., -required_n_media_times:, :]
+    else:
+      media_used = media
+
+    l_range = np.arange(window_size - 1, -1, -1, dtype=np.float32)
+    w = []
+    for i in range(window_size):
+      exponent = (l_range[i] - theta) ** 2
+      w.append(alpha**exponent)
+    w = np.stack(w, axis=0)
+    w_sum = np.sum(w, axis=0, keepdims=True)
+    w_norm = np.divide(w, w_sum, out=np.zeros_like(w), where=w_sum != 0)
+    w_expanded = np.expand_dims(w_norm, axis=3)
+
+    expected = []
+    for t in range(n_times_output):
+      window_vals = []
+      for i in range(window_size):
+        window_vals.append(media_used[..., i + t, :])
+      window_vals = np.stack(window_vals, axis=0)
+      weighted = w_expanded * window_vals
+      weighted_sum = np.sum(weighted, axis=0)
+      expected.append(weighted_sum)
+    expected = np.stack(expected, axis=-2)
+    return expected
+
+  def test_raises(self):
+    """Test that exceptions are raised as expected."""
+    with self.assertRaisesRegex(ValueError, "`n_times_output` cannot exceed"):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA,
+          theta=self._THETA,
+          max_lag=self._MAX_LAG,
+          n_times_output=self._N_MEDIA_TIMES + 1,
+      ).forward(self._MEDIA)
+    with self.assertRaisesRegex(ValueError, "`media` batch dims do not"):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA[1:, ...],
+          theta=self._THETA[1:, ...],
+          max_lag=self._MAX_LAG,
+          n_times_output=self._N_MEDIA_TIMES,
+      ).forward(self._MEDIA)
+    with self.assertRaisesRegex(ValueError, "`media` contains a different"):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA,
+          theta=self._THETA,
+          max_lag=self._MAX_LAG,
+          n_times_output=self._N_MEDIA_TIMES,
+      ).forward(self._MEDIA[..., 1:])
+    with self.assertRaisesRegex(
+        ValueError, "`n_times_output` must be positive"
+    ):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA,
+          theta=self._THETA,
+          max_lag=self._MAX_LAG,
+          n_times_output=0,
+      ).forward(self._MEDIA)
+    with self.assertRaisesRegex(ValueError, "`max_lag` must be non-negative"):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA,
+          theta=self._THETA,
+          max_lag=-1,
+          n_times_output=self._N_MEDIA_TIMES,
+      ).forward(self._MEDIA)
+    with self.assertRaisesRegex(ValueError, "theta.+non-negative"):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA,
+          theta=tf.zeros_like(self._THETA) - 0.1,
+          max_lag=self._MAX_LAG,
+          n_times_output=self._N_MEDIA_TIMES,
+      ).forward(self._MEDIA)
+    with self.assertRaisesRegex(
+        ValueError, "`theta` batch dims do not match `alpha` batch dims."
+    ):
+      adstock_hill.DelayedAdstockTransformer(
+          alpha=self._ALPHA,
+          theta=self._THETA[0, ...],
+          max_lag=self._MAX_LAG,
+          n_times_output=self._N_MEDIA_TIMES,
+      ).forward(self._MEDIA)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name="basic",
+          media=_MEDIA,
+          alpha=_ALPHA,
+          theta=_THETA,
+          n_time_output=_N_MEDIA_TIMES,
+      ),
+      dict(
+          testcase_name="no_media_batch_dims",
+          media=_MEDIA[0, 0, ...],
+          alpha=_ALPHA,
+          theta=_THETA,
+          n_time_output=_N_MEDIA_TIMES,
+      ),
+      dict(
+          testcase_name="n_time_output_less",
+          media=_MEDIA,
+          alpha=_ALPHA,
+          theta=_THETA,
+          n_time_output=_N_MEDIA_TIMES - 1,
+      ),
+      dict(
+          testcase_name="max_lag_exceeds_media_times",
+          media=_MEDIA[..., : (_MAX_LAG - 1)],
+          alpha=_ALPHA,
+          theta=_THETA,
+          n_time_output=_N_MEDIA_TIMES,
+      ),
+      dict(
+          testcase_name="excess_history_available",
+          media=_MEDIA,
+          alpha=_ALPHA,
+          theta=_THETA,
+          n_time_output=_N_MEDIA_TIMES - _MAX_LAG - 1,
+      ),
+  )
+  def test_basic_output(self, media, alpha, theta, n_time_output):
+    """Basic test for valid output."""
+    media_transformed = adstock_hill.DelayedAdstockTransformer(
+        alpha, theta, self._MAX_LAG, n_time_output
+    ).forward(media)
+    expected_shape = tf.TensorShape(
+        alpha.shape[:-1]
+        + media.shape[-3:-2]
+        + [n_time_output]
+        + alpha.shape[-1:]
+    )
+    msg = f"{adstock_hill.DelayedAdstockTransformer.__name__}() failed."
+    tf.debugging.assert_equal(
+        media_transformed.shape, expected_shape, message=msg
+    )
+    tf.debugging.assert_all_finite(media_transformed, message=msg)
+    tf.debugging.assert_non_negative(media_transformed, message=msg)
+
+  def test_max_lag_zero(self):
+    """Test max_lag = 0"""
+    media_transformed = adstock_hill.DelayedAdstockTransformer(
+        alpha=self._ALPHA,
+        theta=tf.zeros_like(self._THETA),
+        max_lag=0,
+        n_times_output=self._N_MEDIA_TIMES,
+    ).forward(self._MEDIA)
+    tf.debugging.assert_near(media_transformed, self._MEDIA)
+
+  def test_alpha_zero(self):
+    """Test alpha zero"""
+    media_transformed = adstock_hill.DelayedAdstockTransformer(
+        alpha=tf.zeros_like(self._ALPHA),
+        theta=tf.zeros_like(self._ALPHA),
+        max_lag=self._MAX_LAG,
+        n_times_output=self._N_MEDIA_TIMES,
+    ).forward(self._MEDIA)
+    tf.debugging.assert_near(media_transformed, self._MEDIA)
+
+  def test_theta_zero(self):
+    """Test theta zero"""
+    theta_zero = tf.zeros_like(self._ALPHA)
+    media_transformed = adstock_hill.DelayedAdstockTransformer(
+        alpha=self._ALPHA,
+        theta=theta_zero,
+        max_lag=self._MAX_LAG,
+        n_times_output=self._N_MEDIA_TIMES,
+    ).forward(self._MEDIA)
+    media_np = self._MEDIA.numpy()
+    alpha_np = self._ALPHA.numpy()
+    theta_np = np.zeros_like(alpha_np)
+    expected_np = self._manual_delayed_adstock(
+        media_np, alpha_np, theta_np, self._MAX_LAG, self._N_MEDIA_TIMES
+    )
+    expected_tf = tf.convert_to_tensor(
+        expected_np, dtype=media_transformed.dtype
+    )
+    tf.debugging.assert_near(
+        media_transformed, expected_tf, rtol=1e-4, atol=1e-4
+    )
+
+  def test_alpha_close_to_one(self):
+    """Test alpha close to one"""
+    alpha_close = 0.99999 * tf.ones_like(self._ALPHA)
+    theta_const = 2.0 * tf.ones_like(self._ALPHA)
+    max_lag = self._N_MEDIA_TIMES - 1  # full lag history
+    n_time_output = self._N_MEDIA_TIMES
+    media_transformed = adstock_hill.DelayedAdstockTransformer(
+        alpha=alpha_close,
+        theta=theta_const,
+        max_lag=max_lag,
+        n_times_output=n_time_output,
+    ).forward(self._MEDIA)
+    media_np = self._MEDIA.numpy()
+    alpha_np = alpha_close.numpy()
+    theta_np = theta_const.numpy()
+    expected_np = self._manual_delayed_adstock(
+        media_np, alpha_np, theta_np, max_lag, n_time_output
+    )
+    expected_tf = tf.convert_to_tensor(
+        expected_np, dtype=media_transformed.dtype
+    )
+    msg = f"{adstock_hill.DelayedAdstockTransformer.__name__} with alpha close to one failed."
+    tf.debugging.assert_near(
+        media_transformed, expected_tf, rtol=1e-4, atol=1e-4, message=msg
+    )
+
+  def test_media_all_ones(self):
+    """Test with media tensor of all ones."""
+    media_ones = tf.ones_like(self._MEDIA)
+    media_transformed = adstock_hill.DelayedAdstockTransformer(
+        alpha=self._ALPHA,
+        theta=self._THETA,
+        max_lag=self._MAX_LAG,
+        n_times_output=self._N_MEDIA_TIMES,
+    ).forward(media_ones)
+    media_np = media_ones.numpy()
+    alpha_np = self._ALPHA.numpy()
+    theta_np = self._THETA.numpy()
+    expected_np = self._manual_delayed_adstock(
+        media_np, alpha_np, theta_np, self._MAX_LAG, self._N_MEDIA_TIMES
+    )
+    expected_tf = tf.convert_to_tensor(
+        expected_np, dtype=media_transformed.dtype
+    )
+    msg = (
+        f"{adstock_hill.DelayedAdstockTransformer.__name__} "
+        "with media ones failed."
+    )
+    tf.debugging.assert_near(
+        media_transformed, expected_tf, rtol=1e-4, atol=1e-4, message=msg
+    )
 
 
 class TestHill(parameterized.TestCase):

--- a/meridian/model/model.py
+++ b/meridian/model/model.py
@@ -320,7 +320,9 @@ class Meridian:
   @functools.cached_property
   def non_media_treatments_scaled(self) -> tf.Tensor | None:
     if self.non_media_transformer is not None:
-      return self.non_media_transformer.forward(self.non_media_treatments)  # pytype: disable=attribute-error
+      return self.non_media_transformer.forward(
+          self.non_media_treatments
+      )  # pytype: disable=attribute-error
     else:
       return None
 
@@ -831,6 +833,7 @@ class Meridian:
       alpha: tf.Tensor,
       ec: tf.Tensor,
       slope: tf.Tensor,
+      theta: tf.Tensor | None = None,
       n_times_output: int | None = None,
   ) -> tf.Tensor:
     """Transforms media using Adstock and Hill functions in the desired order.
@@ -841,6 +844,7 @@ class Meridian:
         impressions, but it can be any metric, such as `media_spend`. Clicks are
         often used for paid search ads.
       alpha: Uniform distribution for Adstock and Hill calculations.
+      theta: Adstock peak delay parameter (used only if `adstock='delayed'`).
       ec: Shifted half-normal distribution for Adstock and Hill calculations.
       slope: Deterministic distribution for Adstock and Hill calculations.
       n_times_output: Number of time periods to output. This argument is
@@ -859,11 +863,21 @@ class Meridian:
           "n_times_output is required. This argument is only optional when "
           "`media` has a number of time periods equal to `self.n_media_times`."
       )
-    adstock_transformer = adstock_hill.AdstockTransformer(
-        alpha=alpha,
-        max_lag=self.model_spec.max_lag,
-        n_times_output=n_times_output,
-    )
+    if self.model_spec.adstock == constants.ADSTOCK_GEOMETRIC:
+      adstock_transformer = adstock_hill.GeometricAdstockTransformer(
+          alpha=alpha,
+          max_lag=self.model_spec.max_lag,
+          n_times_output=n_times_output,
+      )
+    elif self.model_spec.adstock == constants.ADSTOCK_DELAYED:
+      adstock_transformer = adstock_hill.DelayedAdstockTransformer(
+          alpha=alpha,
+          theta=theta,
+          max_lag=self.model_spec.max_lag,
+          n_times_output=n_times_output,
+      )
+    else:
+      raise ValueError(f"Unsupported adstock type: {self.model_spec.adstock}")
     hill_transformer = adstock_hill.HillTransformer(
         ec=ec,
         slope=slope,
@@ -886,6 +900,7 @@ class Meridian:
       alpha: tf.Tensor,
       ec: tf.Tensor,
       slope: tf.Tensor,
+      theta: tf.Tensor | None = None,
       n_times_output: int | None = None,
   ) -> tf.Tensor:
     """Transforms reach and frequency (RF) using Hill and Adstock functions.
@@ -896,6 +911,8 @@ class Meridian:
       frequency: Tensor of dimensions `(n_geos, n_media_times, n_rf_channels)`
         containing non-negative media for frequency.
       alpha: Uniform distribution for Adstock and Hill calculations.
+      theta: Adstock peak delay parameter for RF channels (used if
+          `adstock='delayed'`).
       ec: Shifted half-normal distribution for Adstock and Hill calculations.
       slope: Deterministic distribution for Adstock and Hill calculations.
       n_times_output: Number of time periods to output. This argument is
@@ -918,11 +935,21 @@ class Meridian:
         ec=ec,
         slope=slope,
     )
-    adstock_transformer = adstock_hill.AdstockTransformer(
-        alpha=alpha,
-        max_lag=self.model_spec.max_lag,
-        n_times_output=n_times_output,
-    )
+    if self.model_spec.adstock == constants.ADSTOCK_GEOMETRIC:
+      adstock_transformer = adstock_hill.GeometricAdstockTransformer(
+          alpha=alpha,
+          max_lag=self.model_spec.max_lag,
+          n_times_output=n_times_output,
+      )
+    elif self.model_spec.adstock == constants.ADSTOCK_DELAYED:
+      adstock_transformer = adstock_hill.DelayedAdstockTransformer(
+          alpha=alpha,
+          theta=theta,
+          max_lag=self.model_spec.max_lag,
+          n_times_output=n_times_output,
+      )
+    else:
+      raise ValueError(f"Unsupported adstock type: {self.model_spec.adstock}")
     adj_frequency = hill_transformer.forward(frequency)
     rf_out = adstock_transformer.forward(reach * adj_frequency)
 

--- a/meridian/model/posterior_sampler.py
+++ b/meridian/model/posterior_sampler.py
@@ -153,6 +153,11 @@ class PosteriorMCMCSampler:
       combined_beta = tf.zeros(shape=(n_geos, 0), dtype=tf.float32)
       if media_tensors.media is not None:
         alpha_m = yield prior_broadcast.alpha_m
+        theta_m = (
+            yield prior_broadcast.theta_m
+            if mmm.model_spec.adstock == constants.ADSTOCK_DELAYED
+            else tfp.distributions.Deterministic(0.0, name=constants.THETA_M)
+        )
         ec_m = yield prior_broadcast.ec_m
         eta_m = yield prior_broadcast.eta_m
         slope_m = yield prior_broadcast.slope_m
@@ -164,6 +169,7 @@ class PosteriorMCMCSampler:
         media_transformed = adstock_hill_media_fn(
             media=media_tensors.media_scaled,
             alpha=alpha_m,
+            theta=theta_m,
             ec=ec_m,
             slope=slope_m,
         )
@@ -181,6 +187,7 @@ class PosteriorMCMCSampler:
               roi_or_mroi_m,
               slope_m,
               media_transformed,
+              theta_m,
           )
           beta_m = yield tfp.distributions.Deterministic(
               beta_m_value, name=constants.BETA_M
@@ -204,6 +211,11 @@ class PosteriorMCMCSampler:
 
       if rf_tensors.reach is not None:
         alpha_rf = yield prior_broadcast.alpha_rf
+        theta_rf = (
+            yield prior_broadcast.theta_rf
+            if mmm.model_spec.adstock == constants.ADSTOCK_DELAYED
+            else tfp.distributions.Deterministic(0.0, name=constants.THETA_RF)
+        )
         ec_rf = yield prior_broadcast.ec_rf
         eta_rf = yield prior_broadcast.eta_rf
         slope_rf = yield prior_broadcast.slope_rf
@@ -216,6 +228,7 @@ class PosteriorMCMCSampler:
             reach=rf_tensors.reach_scaled,
             frequency=rf_tensors.frequency,
             alpha=alpha_rf,
+            theta=theta_rf,
             ec=ec_rf,
             slope=slope_rf,
         )
@@ -234,6 +247,7 @@ class PosteriorMCMCSampler:
               roi_or_mroi_rf,
               slope_rf,
               rf_transformed,
+              theta_rf,
           )
           beta_rf = yield tfp.distributions.Deterministic(
               beta_rf_value,
@@ -258,6 +272,11 @@ class PosteriorMCMCSampler:
 
       if organic_media_tensors.organic_media is not None:
         alpha_om = yield prior_broadcast.alpha_om
+        theta_om = (
+            yield prior_broadcast.theta_om
+            if mmm.model_spec.adstock == constants.ADSTOCK_DELAYED
+            else tfp.distributions.Deterministic(0.0, name=constants.THETA_OM)
+        )
         ec_om = yield prior_broadcast.ec_om
         eta_om = yield prior_broadcast.eta_om
         slope_om = yield prior_broadcast.slope_om
@@ -269,6 +288,7 @@ class PosteriorMCMCSampler:
         organic_media_transformed = adstock_hill_media_fn(
             media=organic_media_tensors.organic_media_scaled,
             alpha=alpha_om,
+            theta=theta_om,
             ec=ec_om,
             slope=slope_om,
         )
@@ -290,6 +310,11 @@ class PosteriorMCMCSampler:
 
       if organic_rf_tensors.organic_reach is not None:
         alpha_orf = yield prior_broadcast.alpha_orf
+        theta_orf = (
+            yield prior_broadcast.theta_orf
+            if mmm.model_spec.adstock == constants.ADSTOCK_DELAYED
+            else tfp.distributions.Deterministic(0.0, name=constants.THETA_ORF)
+        )
         ec_orf = yield prior_broadcast.ec_orf
         eta_orf = yield prior_broadcast.eta_orf
         slope_orf = yield prior_broadcast.slope_orf
@@ -302,6 +327,7 @@ class PosteriorMCMCSampler:
             reach=organic_rf_tensors.organic_reach_scaled,
             frequency=organic_rf_tensors.organic_frequency,
             alpha=alpha_orf,
+            theta=theta_orf,
             ec=ec_orf,
             slope=slope_orf,
         )

--- a/meridian/model/prior_distribution.py
+++ b/meridian/model/prior_distribution.py
@@ -71,6 +71,10 @@ class PriorDistribution:
   | `alpha_rf`            | `n_rf_channels`            |
   | `alpha_om`            | `n_organic_media_channels` |
   | `alpha_orf`           | `n_organic_rf_channels`    |
+  | `theta_m`             | `n_media_channels`         |
+  | `theta_rf`            | `n_rf_channels`            |
+  | `theta_om`            | `n_organic_media_channels` |
+  | `theta_orf`           | `n_organic_rf_channels`    |
   | `ec_m`                | `n_media_channels`         |
   | `ec_rf`               | `n_rf_channels`            |
   | `ec_om`               | `n_organic_media_channels` |
@@ -175,6 +179,18 @@ class PriorDistribution:
       organic media input. Default distribution is `Uniform(0.0, 1.0)`.
     alpha_orf: Prior distribution on the `geometric decay` Adstock parameter for
       organic RF input. Default distribution is `Uniform(0.0, 1.0)`.
+    theta_m: Prior distribution on the `delay` parameter for the Delayed
+      Adstock function for media input. Default distribution is
+      `Uniform(0.0, 8.0)`.
+    theta_rf: Prior distribution on the `delay` parameter for the Delayed
+      Adstock function for RF input. Default distribution is
+      `Uniform(0.0, 8.0)`.
+    theta_om: Prior distribution on the `delay` parameter for the Delayed
+      Adstock function for organic media input. Default distribution is
+      `Uniform(0.0, 8.0)`.
+    theta_orf: Prior distribution on the `delay` parameter for the Delayed
+      Adstock function for organic RF input. Default distribution is
+      `Uniform(0.0, 8.0)`.
     ec_m: Prior distribution on the `half-saturation` Hill parameter for media
       input. Default distribution is `TruncatedNormal(0.8, 0.8, 0.1, 10)`.
     ec_rf: Prior distribution on the `half-saturation` Hill parameter for RF
@@ -324,6 +340,26 @@ class PriorDistribution:
       default_factory=lambda: tfp.distributions.Uniform(
           0.0, 1.0, name=constants.ALPHA_ORF
       ),
+  )
+  theta_m: tfp.distributions.Distribution = dataclasses.field(
+      default_factory=lambda: tfp.distributions.Uniform(
+          0.0, constants.DEFAULT_MAX_LAG - 1, name=constants.THETA_M
+      )
+  )
+  theta_rf: tfp.distributions.Distribution = dataclasses.field(
+      default_factory=lambda: tfp.distributions.Uniform(
+          0.0, constants.DEFAULT_MAX_LAG - 1, name=constants.THETA_RF
+      )
+  )
+  theta_om: tfp.distributions.Distribution = dataclasses.field(
+      default_factory=lambda: tfp.distributions.Uniform(
+          0.0, constants.DEFAULT_MAX_LAG - 1, name=constants.THETA_OM
+      )
+  )
+  theta_orf: tfp.distributions.Distribution = dataclasses.field(
+      default_factory=lambda: tfp.distributions.Uniform(
+          0.0, constants.DEFAULT_MAX_LAG - 1, name=constants.THETA_ORF
+      )
   )
   ec_m: tfp.distributions.Distribution = dataclasses.field(
       default_factory=lambda: tfp.distributions.TruncatedNormal(
@@ -506,6 +542,7 @@ class PriorDistribution:
     _validate_media_custom_priors(self.roi_m)
     _validate_media_custom_priors(self.mroi_m)
     _validate_media_custom_priors(self.alpha_m)
+    _validate_media_custom_priors(self.theta_m)
     _validate_media_custom_priors(self.ec_m)
     _validate_media_custom_priors(self.slope_m)
     _validate_media_custom_priors(self.eta_m)
@@ -527,6 +564,7 @@ class PriorDistribution:
         )
 
     _validate_organic_media_custom_priors(self.alpha_om)
+    _validate_organic_media_custom_priors(self.theta_om)
     _validate_organic_media_custom_priors(self.ec_om)
     _validate_organic_media_custom_priors(self.slope_om)
     _validate_organic_media_custom_priors(self.eta_om)
@@ -548,6 +586,7 @@ class PriorDistribution:
         )
 
     _validate_organic_rf_custom_priors(self.alpha_orf)
+    _validate_organic_rf_custom_priors(self.theta_orf)
     _validate_organic_rf_custom_priors(self.ec_orf)
     _validate_organic_rf_custom_priors(self.slope_orf)
     _validate_organic_rf_custom_priors(self.eta_orf)
@@ -567,6 +606,7 @@ class PriorDistribution:
     _validate_rf_custom_priors(self.roi_rf)
     _validate_rf_custom_priors(self.mroi_rf)
     _validate_rf_custom_priors(self.alpha_rf)
+    _validate_rf_custom_priors(self.theta_rf)
     _validate_rf_custom_priors(self.ec_rf)
     _validate_rf_custom_priors(self.slope_rf)
     _validate_rf_custom_priors(self.eta_rf)
@@ -685,6 +725,18 @@ class PriorDistribution:
     )
     alpha_orf = tfp.distributions.BatchBroadcast(
         self.alpha_orf, n_organic_rf_channels, name=constants.ALPHA_ORF
+    )
+    theta_m = tfp.distributions.BatchBroadcast(
+        self.theta_m, n_media_channels, name=constants.THETA_M
+    )
+    theta_rf = tfp.distributions.BatchBroadcast(
+        self.theta_rf, n_rf_channels, name=constants.THETA_RF
+    )
+    theta_om = tfp.distributions.BatchBroadcast(
+        self.theta_om, n_organic_media_channels, name=constants.THETA_OM
+    )
+    theta_orf = tfp.distributions.BatchBroadcast(
+        self.theta_orf, n_organic_rf_channels, name=constants.THETA_ORF
     )
     ec_m = tfp.distributions.BatchBroadcast(
         self.ec_m, n_media_channels, name=constants.EC_M
@@ -807,6 +859,10 @@ class PriorDistribution:
         alpha_rf=alpha_rf,
         alpha_om=alpha_om,
         alpha_orf=alpha_orf,
+        theta_m=theta_m,
+        theta_rf=theta_rf,
+        theta_om=theta_om,
+        theta_orf=theta_orf,
         ec_m=ec_m,
         ec_rf=ec_rf,
         ec_om=ec_om,

--- a/meridian/model/prior_distribution_test.py
+++ b/meridian/model/prior_distribution_test.py
@@ -19,6 +19,7 @@ import warnings
 from absl.testing import absltest
 from absl.testing import parameterized
 from meridian import constants as c
+from meridian.model import spec
 from meridian.model import prior_distribution
 import numpy as np
 import tensorflow_probability as tfp
@@ -1399,6 +1400,21 @@ class PriorDistributionTest(parameterized.TestCase):
     self.assertEqual(
         prior_distribution.distributions_are_equal(a, b), expected_result
     )
+
+  def test_theta_prior_default_for_delayed(self):
+    model_spec = spec.ModelSpec(adstock='delayed', max_lag=6)
+    theta_dist = model_spec.prior.theta_m
+    self.assertIsInstance(theta_dist, tfp.distributions.Uniform)
+    self.assertAlmostEqual(theta_dist.low.numpy(), 0.0, places=6)
+    self.assertAlmostEqual(theta_dist.high.numpy(), 6.0, places=6)
+
+  def test_valid_custom_theta_prior(self):
+    theta = tfp.distributions.Uniform(low=0.0, high=7.0, name='theta_m')
+    model_spec = spec.ModelSpec(
+        adstock='delayed',
+        prior=prior_distribution.PriorDistribution(theta_m=theta),
+    )
+    self.assertIsInstance(model_spec.prior.theta_m, tfp.distributions.Uniform)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
resolves #385

This PR implements an optional delayed adstock function to address the feature request for more flexible carryover effects, especially when dealing with channels that exhibit longer conversion periods. In my experience with travel, real estate, and other high-involvement purchases, the impact of marketing spend can peak days or even weeks after the initial touchpoint.

Previous workarounds, such as adjusting the `max_lag` parameter or shifting the input data manually, have proven too inflexible and ad hoc.

**Key Changes:**

1. **ModelSpec Modification:**
   - Added a new field `adstock` (defaulting to `"geometric"`) in the `ModelSpec` class. When set to `"delayed"`, the model will switch to using the delayed adstock transformation.
   - Users can now activate delayed adstock by configuring the model as follows:
     
     ```python
     model_spec = meridian.model.spec.ModelSpec(adstock="delayed")
     ```

2. **Delayed Adstock Implementation:**
   - Introduced a new transformer class, `DelayedAdstockTransformer`, which computes adstock weights according to the following formula:
     
     ```math
     w_d(l; alpha, theta) = alpha^((l - theta)^2)
     ```
     
     where theta is the delay parameter. This formulation is proposed by [Bayesian Methods for Media Mix Modeling with Carryover and Shape Effects](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/46001.pdf).

3. **Prior Distributions:**
   - New Uniform priors have been added for the delay parameters (`theta_m`, `theta_rf`, etc.) in the `PriorDistribution` class.
   - By default, `theta` is assigned a Uniform prior over the range `[0, max_lag - 1]`. This choice is noninformative and allows the model to learn the appropriate delay from data. In our reading (e.g., *Bayesian Methods for Media Mix Modeling with Carryover and Shape Effects*, section 2.1), a uniform prior for delay is suitable when no strong prior assumptions are available.