### PR TITLE
Fix TypeError in save_meridian for .textproto & .txtpb formats

### DIFF
--- a/schema/serde/meridian_serde.py
+++ b/schema/serde/meridian_serde.py
@@ -362,7 +362,7 @@ def save_meridian(
     if file_path.endswith('.binpb'):
       f.write(serialized_kernel.SerializeToString())
     elif file_path.endswith('.textproto') or file_path.endswith('.txtpb'):
-      f.write(text_format.MessageToString(serialized_kernel))
+      f.write(text_format.MessageToString(serialized_kernel).encode('utf-8'))
     else:
       raise ValueError(f'Unsupported file type: {file_path}')
 


### PR DESCRIPTION
## Summary
Fixes TypeError when saving Meridian models in textproto format

## Problem
When calling `save_meridian()` with a `.textproto` or `.txtpb` file path, 
the function raises:
TypeError: a bytes-like object is required, not 'str'

This occurs because:
- The file is opened in binary mode (`'wb'`) on line 355
- `text_format.MessageToString()` returns a string, not bytes
- Writing a string to a binary file causes the TypeError

## Solution
Encode the string to UTF-8 bytes before writing:
```python
f.write(text_format.MessageToString(serialized_kernel).encode('utf-8'))
```
## Testing
- Tested manually with .textproto format
- Confirms the TypeError is resolved
- .binpb format unchanged (already returns bytes)