### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build meridian core distribution
         uses: ./.github/actions/build
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Check meridian version
       - uses: ./.github/actions/install-meridian
@@ -85,7 +85,7 @@ jobs:
       cancel-in-progress: true
     name: pytest (python-${{ matrix.python-version }}, backend-${{ matrix.meridian-backend }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !contains(github.event.head_commit.message, '#skip-pytest') }}
       - uses: ./.github/actions/install-meridian
         if: ${{ !contains(github.event.head_commit.message, '#skip-pytest') }}
@@ -103,9 +103,9 @@ jobs:
     timeout-minutes: 20
     name: pytest-schema
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !contains(github.event.head_commit.message, '#skip-pytest') }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: ${{ !contains(github.event.head_commit.message, '#skip-pytest') }}
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/proto-publish.yml
+++ b/.github/workflows/proto-publish.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/build
         with:
           python_version: ${{ env.USE_PYTHON_VERSION }}
@@ -48,7 +48,7 @@ jobs:
     outputs:
       new_version: ${{ steps.compare_versions.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Get mmm-proto-schema version
         id: get_proto_version
         uses: ./.github/actions/get-proto-version
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: write # Allow to create tags
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/create-version-tag
         with:
           new_version: proto-v${{ needs.check-proto-version.outputs.new_version }}
@@ -101,7 +101,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: dist/
@@ -128,7 +128,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/build
         with:
           python_version: ${{ env.USE_PYTHON_VERSION }}
@@ -43,7 +43,7 @@ jobs:
     outputs:
       new_version: ${{ steps.version_check.outputs.new_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/install-meridian
         with:
@@ -73,7 +73,7 @@ jobs:
     permissions:
       contents: write # Allow to create tags
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/create-version-tag
         with:
           new_version: v${{ needs.check-version.outputs.new_version }}
@@ -101,7 +101,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: dist/
@@ -129,7 +129,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ env.BUILD_ARTIFACT_NAME }}
           path: dist/


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | ci.yml, proto-publish.yml, publish.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | proto-publish.yml, publish.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | ci.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
