### PR TITLE
Fix: TypeError: unhashable type: 'list' in WeeklyOptimizationGrid.create() when using per-channel adstock_decay_spec/saturation_spec

### DIFF
--- a/meridian/analysis/weekly_optimization_grid.py
+++ b/meridian/analysis/weekly_optimization_grid.py
@@ -247,7 +247,9 @@ class WeeklyOptimizationGrid:
       slope_m = to_float(inf_data.slope_m)
       beta_gm = to_float(inf_data.beta_gm)
       decay_m = model_context.adstock_decay_spec.media
+      decay_m = tuple(decay_m) if isinstance(decay_m, list) else decay_m
       sat_m = model_context.saturation_spec.media
+      sat_m = tuple(sat_m) if isinstance(sat_m, list) else sat_m
     else:
       media_base_scaled = None
       alpha_m = None
@@ -306,7 +308,9 @@ class WeeklyOptimizationGrid:
       slope_rf = to_float(inf_data.slope_rf)
       beta_grf = to_float(inf_data.beta_grf)
       decay_rf = model_context.adstock_decay_spec.rf
+      decay_rf = tuple(decay_rf) if isinstance(decay_rf, list) else decay_rf
       sat_rf = model_context.saturation_spec.rf
+      sat_rf = tuple(sat_rf) if isinstance(sat_rf, list) else sat_rf
     else:
       reach_base_scaled = None
       frequency_base = None


### PR DESCRIPTION
Error:
ModelSpec supports specifying adstock_decay_spec and saturation_spec as a per-channel dictionary. 

When built from a per-channel dict with mixed decay types, .media/.rf resolve to a plain Python list of strings. JAX requires static arguments to be hashable, so this raises:

```
ValueError: Non-hashable static arguments are not supported. An error occurred while trying to hash an object of type <class 'list'>, ['binomial', 'binomial', 'binomial', 'geometric', 'geometric', 'binomial']. The error was:
TypeError: unhashable type: 'list'
```

Fix:
Coerce decay_m, sat_m, decay_rf, and sat_rf to tuple before they are passed as static arguments into _compute_batch, since tuples of strings are hashable and JAX accepts them as static args. Single-string specs (the uniform, non-per-channel case) are left untouched, since they were already hashable and working correctly.

Test:
Reproduced the original failure using a fitted model with a dict-based adstock_decay_spec containing a mix of "binomial" and "geometric" values across channels.

Confirmed WeeklyOptimizationGrid.create() completes successfully after the fix, using the same model and config that previously raised the error